### PR TITLE
Remove positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Remotr
 
+From version 2.0.0 and up this gem is only compatible with Rails 5.
+
 Example usage:
 
 ```ruby

--- a/lib/remotr/test_helpers.rb
+++ b/lib/remotr/test_helpers.rb
@@ -25,7 +25,7 @@ module Remotr
           case method
           when :post
             query_string = options[:query].to_query.present? ? "?#{options[:query].to_query}" : nil
-            send method, "#{url.path}#{query_string}", options[:body], options[:headers]
+            send method, "#{url.path}#{query_string}", params: options[:body], headers: options[:headers]
           when :get
             send method, url.path, params: options[:query], headers: options[:headers]
           else

--- a/lib/remotr/test_helpers.rb
+++ b/lib/remotr/test_helpers.rb
@@ -25,7 +25,7 @@ module Remotr
           case method
           when :post
             query_string = options[:query].to_query.present? ? "?#{options[:query].to_query}" : nil
-            send method, "#{url.path}#{query_string}", params: options[:body], headers: options[:headers]
+            send method, "#{url.path}#{query_string}", body: options[:body], headers: options[:headers]
           when :get
             send method, url.path, params: options[:query], headers: options[:headers]
           else

--- a/lib/remotr/test_helpers.rb
+++ b/lib/remotr/test_helpers.rb
@@ -27,7 +27,7 @@ module Remotr
             query_string = options[:query].to_query.present? ? "?#{options[:query].to_query}" : nil
             send method, "#{url.path}#{query_string}", options[:body], options[:headers]
           when :get
-            send method, url.path, options[:query], options[:headers]
+            send method, url.path, params: options[:query], headers: options[:headers]
           else
             fail NotImplementedError
           end

--- a/remotr.gemspec
+++ b/remotr.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name        = 'remotr'
-  spec.version     = '1.1.5'
-  spec.date        = '2017-08-03'
+  spec.version     = '2.0.0'
+  spec.date        = '2017-09-19'
   spec.summary     = "Wrapping HTTParty"
   spec.description = "See https://github.com/bukowskis/remotr"
   spec.authors     = %w{ bukowskis }


### PR DESCRIPTION
In order to fix deprecation warnings when running specs we remove positional arguments with keyword arguments instead.